### PR TITLE
Space dc-tag further from the message author

### DIFF
--- a/scss/_tag.scss
+++ b/scss/_tag.scss
@@ -18,6 +18,7 @@
     font-size: 0.625rem;
     padding-inline: 0.275rem;
     text-transform: uppercase;
+    margin-left: 0.125rem;
 
     &-verified {
         @extend .#{vars.$prefix}tag;


### PR DESCRIPTION
added `0.125rem` margin to the left.

Before:
![image](https://github.com/user-attachments/assets/cce62988-349f-45f7-8d20-e6a028b5a8bb)
After:
![image](https://github.com/user-attachments/assets/21ba3811-9716-4c0e-8df5-a37bd7cedd07)

Normally I edited the proper file, just can't test the modification.
Not sure if the difference is noticeable for others but it just felt to close compared to discord's app.

Feel free to close it if you don't think it's a valuable PR.

Great job on the rest of the Repo ! 